### PR TITLE
Update README.md

### DIFF
--- a/arcgis_map_sdk/README.md
+++ b/arcgis_map_sdk/README.md
@@ -22,7 +22,7 @@ dependencies:
 (Android) In `<app>/android/app/proguard-rules.pro` add:
 
 ```
--keep class dev.fluttercommunity.arcgis_map_sdk.** { *; }
+-keep class dev.fluttercommunity.arcgis_map_sdk_android.** { *; }
 ```
 
 


### PR DESCRIPTION
The correct package name for proguard is `dev.fluttercommunity.arcgis_map_sdk_android` isntead of `dev.fluttercommunity.arcgis_map_sdk`