### PR TITLE
MapView.scale NaN

### DIFF
--- a/arcgis_map_sdk_android/android/src/main/kotlin/dev/fluttercommunity/arcgis_map_sdk_android/ArcgisMapView.kt
+++ b/arcgis_map_sdk_android/android/src/main/kotlin/dev/fluttercommunity/arcgis_map_sdk_android/ArcgisMapView.kt
@@ -135,6 +135,11 @@ internal class ArcgisMapView(
     }
 
     private fun onZoomIn(call: MethodCall, result: MethodChannel.Result) {
+        if(mapView.mapScale.isNaN()) {
+            result.error("Error", "MapView.mapScale is NaN. Maybe the map is not completely loaded.",null)
+            return
+        }
+
         val lodFactor = call.argument<Int>("lodFactor")!!
         val currentZoomLevel = getZoomLevel(mapView)
         val totalZoomLevel = currentZoomLevel + lodFactor
@@ -154,6 +159,11 @@ internal class ArcgisMapView(
     }
 
     private fun onZoomOut(call: MethodCall, result: MethodChannel.Result) {
+        if(mapView.mapScale.isNaN()) {
+            result.error("Error", "MapView.mapScale is NaN. Maybe the map is not completely loaded.",null)
+            return
+        }
+
         val lodFactor = call.argument<Int>("lodFactor")!!
         val currentZoomLevel = getZoomLevel(mapView)
         val totalZoomLevel = currentZoomLevel - lodFactor

--- a/arcgis_map_sdk_android/android/src/main/kotlin/dev/fluttercommunity/arcgis_map_sdk_android/ArcgisMapView.kt
+++ b/arcgis_map_sdk_android/android/src/main/kotlin/dev/fluttercommunity/arcgis_map_sdk_android/ArcgisMapView.kt
@@ -37,10 +37,10 @@ import kotlin.math.roundToInt
  * A starting point for documentation can be found here: https://developers.arcgis.com/android/maps-2d/tutorials/display-a-map/
  * */
 internal class ArcgisMapView(
-    context: Context,
-    private val viewId: Int,
-    private val binaryMessenger: BinaryMessenger,
-    private val mapOptions: ArcgisMapOptions,
+        context: Context,
+        private val viewId: Int,
+        private val binaryMessenger: BinaryMessenger,
+        private val mapOptions: ArcgisMapOptions,
 ) : PlatformView {
 
     private val view: View = LayoutInflater.from(context).inflate(R.layout.vector_map_view, null)
@@ -52,7 +52,7 @@ internal class ArcgisMapView(
     private lateinit var centerPositionStreamHandler: CenterPositionStreamHandler
 
     private val methodChannel =
-        MethodChannel(binaryMessenger, "dev.fluttercommunity.arcgis_map_sdk/$viewId")
+            MethodChannel(binaryMessenger, "dev.fluttercommunity.arcgis_map_sdk/$viewId")
 
     override fun getView(): View = view
 
@@ -82,18 +82,18 @@ internal class ArcgisMapView(
         mapView.addViewpointChangedListener {
             val center = mapView.visibleArea.extent.center
             val wgs84Center =
-                GeometryEngine.project(center, SpatialReferences.getWgs84()) as Point
+                    GeometryEngine.project(center, SpatialReferences.getWgs84()) as Point
             centerPositionStreamHandler.add(
-                LatLng(
-                    longitude = wgs84Center.x,
-                    latitude = wgs84Center.y
-                )
+                    LatLng(
+                            longitude = wgs84Center.x,
+                            latitude = wgs84Center.y
+                    )
             )
         }
 
         val viewPoint = Viewpoint(
-            mapOptions.initialCenter.latitude, mapOptions.initialCenter.longitude,
-            getMapScale(mapOptions.zoom.roundToInt()),
+                mapOptions.initialCenter.latitude, mapOptions.initialCenter.longitude,
+                getMapScale(mapOptions.zoom.roundToInt()),
         )
         mapView.setViewpoint(viewPoint)
 
@@ -128,15 +128,15 @@ internal class ArcgisMapView(
         centerPositionStreamHandler = CenterPositionStreamHandler()
 
         EventChannel(binaryMessenger, "dev.fluttercommunity.arcgis_map_sdk/$viewId/zoom")
-            .setStreamHandler(zoomStreamHandler)
+                .setStreamHandler(zoomStreamHandler)
 
         EventChannel(binaryMessenger, "dev.fluttercommunity.arcgis_map_sdk/$viewId/centerPosition")
-            .setStreamHandler(centerPositionStreamHandler)
+                .setStreamHandler(centerPositionStreamHandler)
     }
 
     private fun onZoomIn(call: MethodCall, result: MethodChannel.Result) {
-        if(mapView.mapScale.isNaN()) {
-            result.error("Error", "MapView.mapScale is NaN. Maybe the map is not completely loaded.",null)
+        if (mapView.mapScale.isNaN()) {
+            result.error("Error", "MapView.mapScale is NaN. Maybe the map is not completely loaded.", null)
             return
         }
 
@@ -159,8 +159,8 @@ internal class ArcgisMapView(
     }
 
     private fun onZoomOut(call: MethodCall, result: MethodChannel.Result) {
-        if(mapView.mapScale.isNaN()) {
-            result.error("Error", "MapView.mapScale is NaN. Maybe the map is not completely loaded.",null)
+        if (mapView.mapScale.isNaN()) {
+            result.error("Error", "MapView.mapScale is NaN. Maybe the map is not completely loaded.", null)
             return
         }
 
@@ -187,10 +187,10 @@ internal class ArcgisMapView(
 
         // https://developers.arcgis.com/android/api-reference/reference/com/esri/arcgisruntime/mapping/view/MapView.html#setViewInsets(double,double,double,double)
         mapView.setViewInsets(
-            viewPadding.left,
-            viewPadding.top,
-            viewPadding.right,
-            viewPadding.bottom
+                viewPadding.left,
+                viewPadding.top,
+                viewPadding.right,
+                viewPadding.bottom
         )
 
         result.success(true)
@@ -215,7 +215,7 @@ internal class ArcgisMapView(
         }
 
         val existingIds =
-            defaultGraphicsOverlay.graphics.mapNotNull { it.attributes["id"] as? String }
+                defaultGraphicsOverlay.graphics.mapNotNull { it.attributes["id"] as? String }
         val newIds = newGraphic.mapNotNull { it.attributes["id"] as? String }
 
         if (existingIds.any(newIds::contains)) {
@@ -255,8 +255,8 @@ internal class ArcgisMapView(
         val animationOptionMap = (arguments["animationOptions"] as Map<String, Any>?)
 
         val animationOptions =
-            if (animationOptionMap == null || animationOptionMap.isEmpty()) null
-            else animationOptionMap.parseToClass<AnimationOptions>()
+                if (animationOptionMap == null || animationOptionMap.isEmpty()) null
+                else animationOptionMap.parseToClass<AnimationOptions>()
 
         val scale = if (zoomLevel != null) {
             getMapScale(zoomLevel)
@@ -266,9 +266,9 @@ internal class ArcgisMapView(
 
         val initialViewPort = Viewpoint(point.latitude, point.longitude, scale)
         val future = mapView.setViewpointAsync(
-            initialViewPort,
-            (animationOptions?.duration?.toFloat() ?: 0F) / 1000,
-            animationOptions?.animationCurve ?: AnimationCurve.LINEAR,
+                initialViewPort,
+                (animationOptions?.duration?.toFloat() ?: 0F) / 1000,
+                animationOptions?.animationCurve ?: AnimationCurve.LINEAR,
         )
 
         future.addDoneListener {
@@ -282,8 +282,8 @@ internal class ArcgisMapView(
 
     private fun onToggleBaseMap(call: MethodCall, result: MethodChannel.Result) {
         val newStyle = gson.fromJson<BasemapStyle>(
-            call.arguments as String,
-            object : TypeToken<BasemapStyle>() {}.type
+                call.arguments as String,
+                object : TypeToken<BasemapStyle>() {}.type
         )
         map.basemap = Basemap(newStyle)
         result.success(true)
@@ -306,7 +306,7 @@ internal class ArcgisMapView(
      * https://community.esri.com/t5/arcgis-runtime-sdk-for-android-questions/mapview-graphicsoverlays-add-does-not-update-the/m-p/1240825#M5931
      */
     private fun updateMap() {
-        if(mapView.mapScale.isNaN()) {
+        if (mapView.mapScale.isNaN()) {
             return
         }
         mapView.setViewpointScaleAsync(mapView.mapScale)

--- a/arcgis_map_sdk_android/android/src/main/kotlin/dev/fluttercommunity/arcgis_map_sdk_android/ArcgisMapView.kt
+++ b/arcgis_map_sdk_android/android/src/main/kotlin/dev/fluttercommunity/arcgis_map_sdk_android/ArcgisMapView.kt
@@ -306,6 +306,9 @@ internal class ArcgisMapView(
      * https://community.esri.com/t5/arcgis-runtime-sdk-for-android-questions/mapview-graphicsoverlays-add-does-not-update-the/m-p/1240825#M5931
      */
     private fun updateMap() {
+        if(mapView.mapScale.isNaN()) {
+            return
+        }
         mapView.setViewpointScaleAsync(mapView.mapScale)
     }
 

--- a/arcgis_map_sdk_ios/ios/Classes/ArcgisMapView.swift
+++ b/arcgis_map_sdk_ios/ios/Classes/ArcgisMapView.swift
@@ -135,6 +135,11 @@ class ArcgisMapView: NSObject, FlutterPlatformView {
     }
 
     private func onZoomIn(_ call: FlutterMethodCall, _ result: @escaping FlutterResult) {
+        if(mapView.mapScale.isNaN) {
+            result(FlutterError(code: "unknown_error", message: "MapView.mapScale is NaN. Maybe the map is not completely loaded.", details: nil))
+            return
+        }
+        
         let lodFactor = (call.arguments! as! Dictionary<String, Any>)["lodFactor"]! as! Int
         let currentZoomLevel = getZoomLevel(mapView.mapScale)
         let totalZoomLevel = currentZoomLevel + lodFactor
@@ -148,6 +153,11 @@ class ArcgisMapView: NSObject, FlutterPlatformView {
     }
 
     private func onZoomOut(_ call: FlutterMethodCall, _ result: @escaping FlutterResult) {
+        if(mapView.mapScale.isNaN) {
+            result(FlutterError(code: "unknown_error", message: "MapView.mapScale is NaN. Maybe the map is not completely loaded.", details: nil))
+            return
+        }
+        
         let lodFactor = (call.arguments! as! Dictionary<String, Any>)["lodFactor"]! as! Int
         let currentZoomLevel = getZoomLevel(mapView.mapScale)
         let totalZoomLevel = currentZoomLevel - lodFactor


### PR DESCRIPTION
In some cases the scale of mapView is NaN. This PR adds error handling to prevent crashes.
On Android: `updateMap()` gets ignored, if scale == NaN