### PR TITLE
image-export

### DIFF
--- a/arcgis_map_sdk/README.md
+++ b/arcgis_map_sdk/README.md
@@ -109,6 +109,7 @@ Checkout the example app `example/lib/main.dart` for more details.
 | toggleBaseMap        |  ✅  |  ✅  |    ✅    |
 | moveCamera           |  ✅  |  ✅  |    ✅    |
 | moveCameraToPoints   |      |  ✅  |    ✅    |
+| exportImage          |      |  ✅  |    ✅    |
 | zoomIn               |  ✅  |  ✅  |    ✅    |
 | zoomOut              |  ✅  |  ✅  |    ✅    |
 | getZoom              |  ✅  |  ✅  |    ✅    |

--- a/arcgis_map_sdk/lib/src/arcgis_map_controller.dart
+++ b/arcgis_map_sdk/lib/src/arcgis_map_controller.dart
@@ -52,6 +52,8 @@ class ArcgisMapController {
     );
   }
 
+  /// Exports an image of the currently visible map view containing all
+  /// layers of that view.
   Future<Uint8List> exportImage() {
     return ArcgisMapPlatform.instance.exportImage(mapId);
   }

--- a/arcgis_map_sdk/lib/src/arcgis_map_controller.dart
+++ b/arcgis_map_sdk/lib/src/arcgis_map_controller.dart
@@ -52,6 +52,10 @@ class ArcgisMapController {
     );
   }
 
+  Future<Uint8List> exportImage() {
+    return ArcgisMapPlatform.instance.exportImage(mapId);
+  }
+
   Future<GraphicsLayer> addGraphicsLayer({
     required String layerId,
     required GraphicsLayerOptions options,

--- a/arcgis_map_sdk_android/android/src/main/kotlin/dev/fluttercommunity/arcgis_map_sdk_android/ArcgisMapView.kt
+++ b/arcgis_map_sdk_android/android/src/main/kotlin/dev/fluttercommunity/arcgis_map_sdk_android/ArcgisMapView.kt
@@ -1,6 +1,7 @@
 package dev.fluttercommunity.arcgis_map_sdk_android
 
 import android.content.Context
+import android.graphics.Bitmap
 import android.view.LayoutInflater
 import android.view.View
 import com.esri.arcgisruntime.ArcGISRuntimeEnvironment
@@ -39,6 +40,7 @@ import io.flutter.plugin.common.EventChannel
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.platform.PlatformView
+import java.io.ByteArrayOutputStream
 import kotlin.math.exp
 import kotlin.math.ln
 import kotlin.math.roundToInt
@@ -187,6 +189,8 @@ internal class ArcgisMapView(
                     call,
                     result
                 )
+
+                "export_image" -> onExportImage(result)
 
                 else -> result.notImplemented()
             }
@@ -517,6 +521,20 @@ internal class ArcgisMapView(
         }
     }
 
+    private fun onExportImage(result: MethodChannel.Result) {
+        result.finishWithFuture(
+            mapResult = { bitmap ->
+                val stream = ByteArrayOutputStream()
+                bitmap.compress(Bitmap.CompressFormat.PNG, 100, stream)
+                val byteArray = stream.toByteArray()
+                bitmap.recycle()
+                byteArray
+            },
+            getFuture = { mapView.exportImageAsync() }
+        )
+
+    }
+
     /**
      * Convert map scale to zoom level
      * https://developers.arcgis.com/documentation/mapping-apis-and-services/reference/zoom-levels-and-scale/#conversion-tool
@@ -561,13 +579,23 @@ internal class ArcgisMapView(
 
     // region helper methods
 
-    private fun MethodChannel.Result.finishWithFuture(function: () -> ListenableFuture<*>) {
+    /**
+     * Safely awaits the provide future and respond to the MethodChannel with the result
+     * or an error.
+     *
+     * @param mapResult optional transformation of the returned value of the future. If null will default to Boolean true.
+     * @param getFuture A callback that returns the future that will be awaited. This invocation is also caught.
+     */
+    private fun <T> MethodChannel.Result.finishWithFuture(
+        mapResult: (T) -> Any = { _ -> true },
+        getFuture: () -> ListenableFuture<T>
+    ) {
         try {
-            val future = function()
+            val future = getFuture()
             future.addDoneListener {
                 try {
-                    future.get()
-                    success(true)
+                    val result = future.get()
+                    success(mapResult(result))
                 } catch (e: Throwable) {
                     finishWithError(e)
                 }

--- a/arcgis_map_sdk_ios/ios/Classes/ArcgisMapView.swift
+++ b/arcgis_map_sdk_ios/ios/Classes/ArcgisMapView.swift
@@ -16,7 +16,6 @@ class ArcgisMapView: NSObject, FlutterPlatformView {
 
     private var mapScaleObservation: NSKeyValueObservation?
     private var mapVisibleAreaObservation: NSKeyValueObservation?
-    private var layerObservations = Dictionary<String, NSKeyValueObservation>()
 
     private let initialZoom: Int
 
@@ -88,20 +87,6 @@ class ArcgisMapView: NSObject, FlutterPlatformView {
                 AGSArcGISVectorTiledLayer(url: URL(string: url)!)
             }
             map.basemap = AGSBasemap(baseLayers: layers, referenceLayers: nil)
-            layers.forEach { layer in
-                guard let url = layer.url?.absoluteString else {
-                    return
-                }
-                layerObservations.removeValue(forKey: url)
-                
-                layerObservations[url] = layer.observe(\.loadStatus) { [weak self] (layer, notifier) in
-                    guard let self = self else {
-                        return
-                    }
-                    let mapStatus = layer.loadStatus
-                    print("Load status for map: \(layer.url) \(layer.loadStatus)")
-                }
-            }
         }
         
 

--- a/arcgis_map_sdk_ios/ios/Classes/ArcgisMapView.swift
+++ b/arcgis_map_sdk_ios/ios/Classes/ArcgisMapView.swift
@@ -158,6 +158,7 @@ class ArcgisMapView: NSObject, FlutterPlatformView {
             case "location_display_update_display_source_position_manually" : onUpdateLocationDisplaySourcePositionManually(call, result)
             case "location_display_set_data_source_type" : onSetLocationDisplayDataSourceType(call, result)
             case "update_is_attribution_text_visible": onUpdateIsAttributionTextVisible(call, result)
+            case "export_image" : onExportImage(result)
             default:
                 result(FlutterError(code: "Unimplemented", message: "No method matching the name \(call.method)", details: nil))
             }
@@ -515,6 +516,21 @@ class ArcgisMapView: NSObject, FlutterPlatformView {
         
         mapView.isAttributionTextVisible = isVisible
         result(true)
+    }
+    
+    private func onExportImage(_ result: @escaping FlutterResult) {
+        mapView.exportImage { image, error in
+            if let error = error {
+                result(FlutterError(code: "export_error", message: error.localizedDescription, details: nil))
+                return
+            }
+            
+            if let image = image, let imageData = image.pngData() {
+                result(FlutterStandardTypedData(bytes: imageData))
+            } else {
+                result(FlutterError(code: "conversion_error", message: "Failed to convert image to PNG data", details: nil))
+            }
+        }
     }
 
     private func operationWithSymbol(_ call: FlutterMethodCall, _ result: @escaping FlutterResult, handler: (AGSSymbol) -> Void) {

--- a/arcgis_map_sdk_ios/ios/Classes/ArcgisMapView.swift
+++ b/arcgis_map_sdk_ios/ios/Classes/ArcgisMapView.swift
@@ -16,6 +16,7 @@ class ArcgisMapView: NSObject, FlutterPlatformView {
 
     private var mapScaleObservation: NSKeyValueObservation?
     private var mapVisibleAreaObservation: NSKeyValueObservation?
+    private var layerObservations = Dictionary<String, NSKeyValueObservation>()
 
     private let initialZoom: Int
 
@@ -87,7 +88,22 @@ class ArcgisMapView: NSObject, FlutterPlatformView {
                 AGSArcGISVectorTiledLayer(url: URL(string: url)!)
             }
             map.basemap = AGSBasemap(baseLayers: layers, referenceLayers: nil)
+            layers.forEach { layer in
+                guard let url = layer.url?.absoluteString else {
+                    return
+                }
+                layerObservations.removeValue(forKey: url)
+                
+                layerObservations[url] = layer.observe(\.loadStatus) { [weak self] (layer, notifier) in
+                    guard let self = self else {
+                        return
+                    }
+                    let mapStatus = layer.loadStatus
+                    print("Load status for map: \(layer.url) \(layer.loadStatus)")
+                }
+            }
         }
+        
 
         map.minScale = convertZoomLevelToMapScale(mapOptions.minZoom)
         map.maxScale = convertZoomLevelToMapScale(mapOptions.maxZoom)

--- a/arcgis_map_sdk_method_channel/lib/src/method_channel_arcgis_map_plugin.dart
+++ b/arcgis_map_sdk_method_channel/lib/src/method_channel_arcgis_map_plugin.dart
@@ -30,6 +30,13 @@ class MethodChannelArcgisMapPlugin extends ArcgisMapPlatform {
   }
 
   @override
+  Future<Uint8List> exportImage(int mapId) {
+    return _methodChannelBuilder(mapId)
+        .invokeMethod<Uint8List>("export_image")
+        .then((value) => value!);
+  }
+
+  @override
   void setMouseCursor(SystemMouseCursor cursor, int mapId) {
     throw UnimplementedError('setMouseCursor() has not been implemented');
   }

--- a/arcgis_map_sdk_platform_interface/lib/src/arcgis_map_sdk_platform_interface.dart
+++ b/arcgis_map_sdk_platform_interface/lib/src/arcgis_map_sdk_platform_interface.dart
@@ -22,6 +22,10 @@ class ArcgisMapPlatform extends PlatformInterface {
     throw UnimplementedError('init() has not been implemented.');
   }
 
+  Future<Uint8List> exportImage(int mapId)  {
+    throw UnimplementedError('exportImage() has not been implemented.');
+  }
+
   Future<FeatureLayer> addFeatureLayer(
     FeatureLayerOptions options,
     List<Graphic>? data,

--- a/example/lib/export_image_example_page.dart
+++ b/example/lib/export_image_example_page.dart
@@ -1,0 +1,125 @@
+import 'dart:typed_data';
+
+import 'package:arcgis_example/main.dart';
+import 'package:arcgis_map_sdk/arcgis_map_sdk.dart';
+import 'package:flutter/material.dart';
+
+class ExportImageExamplePage extends StatefulWidget {
+  const ExportImageExamplePage({super.key});
+
+  @override
+  State<ExportImageExamplePage> createState() => _ExportImageExamplePageState();
+}
+
+class _ExportImageExamplePageState extends State<ExportImageExamplePage> {
+  final _snackBarKey = GlobalKey<ScaffoldState>();
+  ArcgisMapController? _controller;
+
+  Uint8List? _imageBytes;
+  final initialCenter = const LatLng(51.16, 10.45);
+  late final start = initialCenter;
+  final end = const LatLng(51.16551, 10.45221);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      key: _snackBarKey,
+      appBar: AppBar(),
+      floatingActionButton: FloatingActionButton(
+        child: Icon(Icons.refresh),
+        onPressed: () async {
+          try {
+            final image = await _controller!.exportImage();
+            if (!mounted) return;
+            setState(() => _imageBytes = image);
+          } catch (e, stack) {
+            if (!mounted) return;
+            ScaffoldMessenger.of(_snackBarKey.currentContext!)
+                .showSnackBar(SnackBar(content: Text("$e")));
+            debugPrint("$e");
+            debugPrintStack(stackTrace: stack);
+          }
+        },
+      ),
+      body: Column(
+        children: [
+          Expanded(
+            child: ArcgisMap(
+              apiKey: arcGisApiKey,
+              initialCenter: initialCenter,
+              zoom: 12,
+              basemap: BaseMap.arcgisNavigationNight,
+              mapStyle: MapStyle.twoD,
+              onMapCreated: (controller) {
+                _controller = controller;
+
+                controller.addGraphic(
+                  layerId: "pin",
+                  graphic: PointGraphic(
+                    longitude: initialCenter.longitude,
+                    latitude: initialCenter.latitude,
+                    height: 20,
+                    attributes: Attributes({
+                      'id': "pin1",
+                      'name': "pin1",
+                      'family': 'Pins',
+                    }),
+                    symbol: PictureMarkerSymbol(
+                      assetUri: 'assets/navPointer.png',
+                      width: 56,
+                      height: 56,
+                    ),
+                  ),
+                );
+
+                controller.addGraphic(
+                  layerId: "line",
+                  graphic: PolylineGraphic(
+                    paths: [
+                      [
+                        [start.longitude, start.latitude, 10.0],
+                        [end.longitude, end.latitude, 10.0],
+                      ]
+                    ],
+                    symbol: const SimpleLineSymbol(
+                      color: Colors.purple,
+                      style: PolylineStyle.shortDashDotDot,
+                      width: 3,
+                      marker: LineSymbolMarker(
+                        color: Colors.green,
+                        colorOpacity: 1,
+                        style: MarkerStyle.circle,
+                      ),
+                    ),
+                    attributes: Attributes({'id': "line-1", 'name': "line-1"}),
+                  ),
+                );
+              },
+            ),
+          ),
+          const Divider(),
+          Text(
+            _imageBytes == null
+                ? "Press the button to generate an image"
+                : "This image is a screenshot of the mapview! ⬇️",
+            style: Theme.of(context).textTheme.bodyLarge,
+          ),
+          const SizedBox(height: 8),
+          Expanded(
+            child: _imageBytes == null
+                ? SizedBox()
+                : Container(
+                    padding: EdgeInsets.all(16),
+                    decoration: BoxDecoration(
+                      color: Theme.of(context).primaryColor,
+                      borderRadius: BorderRadius.circular(12),
+                    ),
+                    child: Image.memory(_imageBytes!),
+                  ),
+          ),
+          SizedBox(height: MediaQuery.paddingOf(context).bottom),
+        ],
+      ),
+    );
+  }
+}

--- a/example/lib/export_image_example_page.dart
+++ b/example/lib/export_image_example_page.dart
@@ -114,7 +114,10 @@ class _ExportImageExamplePageState extends State<ExportImageExamplePage> {
                       color: Theme.of(context).primaryColor,
                       borderRadius: BorderRadius.circular(12),
                     ),
-                    child: Image.memory(_imageBytes!),
+                    child: ClipRRect(
+                      child: Image.memory(_imageBytes!),
+                      borderRadius: BorderRadius.circular(12),
+                    ),
                   ),
           ),
           SizedBox(height: MediaQuery.paddingOf(context).bottom),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:core';
 
+import 'package:arcgis_example/export_image_example_page.dart';
 import 'package:arcgis_example/location_indicator_example_page.dart';
 import 'package:arcgis_example/map_elements.dart';
 import 'package:arcgis_example/vector_layer_example_page.dart';
@@ -516,6 +517,10 @@ class _ExampleMapState extends State<ExampleMap> {
                         child: const Text("Show Vector layer example"),
                       ),
                       ElevatedButton(
+                        onPressed: _routeToExportImageExample,
+                        child: const Text("Show export image example"),
+                      ),
+                      ElevatedButton(
                         onPressed: _routeToLocationIndicatorExample,
                         child: const Text("Location indicator example"),
                       ),
@@ -806,6 +811,12 @@ class _ExampleMapState extends State<ExampleMap> {
   void _routeToLocationIndicatorExample() {
     Navigator.of(context).push(
       MaterialPageRoute(builder: (_) => const LocationIndicatorExamplePage()),
+    );
+  }
+
+  void _routeToExportImageExample() {
+    Navigator.of(context).push(
+      MaterialPageRoute(builder: (_) => const ExportImageExamplePage()),
     );
   }
 }


### PR DESCRIPTION
This PR adds support for exporting an image of the ArcgisMapView.

The use case of this feature is simply a full export of the native mapview with all layers that can be shared or persisted by the App. 
A running app give users the ability to share a run visualized on the map or you want to generate a pdf report that contains the map since it helps visualize important data.

