### PR TITLE
add-rotation-and-fix-smaller-issues

### DIFF
--- a/arcgis_map_sdk/lib/src/arcgis_location_display.dart
+++ b/arcgis_map_sdk/lib/src/arcgis_location_display.dart
@@ -47,9 +47,9 @@ class ArcgisLocationDisplay {
     return ArcgisMapPlatform.instance.stopLocationDisplayDataSource(_mapId!);
   }
 
-  void setAutoPanMode(AutoPanMode autoPanMode) {
+  Future<void> setAutoPanMode(AutoPanMode autoPanMode) {
     _assertAttached();
-    ArcgisMapPlatform.instance.setAutoPanMode(autoPanMode.name, _mapId!);
+    return ArcgisMapPlatform.instance.setAutoPanMode(autoPanMode.name, _mapId!);
   }
 
   Future<AutoPanMode> getAutoPanMode() {

--- a/arcgis_map_sdk/lib/src/arcgis_map_controller.dart
+++ b/arcgis_map_sdk/lib/src/arcgis_map_controller.dart
@@ -242,6 +242,10 @@ class ArcgisMapController {
     );
   }
 
+  Future<void> setRotation(double angleDegrees) {
+    return ArcgisMapPlatform.instance.setRotation(angleDegrees, mapId);
+  }
+
   Future<void> addGraphic({required String layerId, required Graphic graphic}) {
     return ArcgisMapPlatform.instance.addGraphic(mapId, layerId, graphic);
   }

--- a/arcgis_map_sdk_android/android/src/main/kotlin/dev/fluttercommunity/arcgis_map_sdk_android/ArcgisMapView.kt
+++ b/arcgis_map_sdk_android/android/src/main/kotlin/dev/fluttercommunity/arcgis_map_sdk_android/ArcgisMapView.kt
@@ -26,7 +26,6 @@ import com.esri.arcgisruntime.mapping.Viewpoint
 import com.esri.arcgisruntime.mapping.view.AnimationCurve
 import com.esri.arcgisruntime.mapping.view.Graphic
 import com.esri.arcgisruntime.mapping.view.GraphicsOverlay
-import com.esri.arcgisruntime.mapping.view.LocationDisplay.AutoPanMode
 import com.esri.arcgisruntime.mapping.view.LocationDisplay.AutoPanMode.*
 import com.esri.arcgisruntime.mapping.view.MapView
 import com.esri.arcgisruntime.symbology.Symbol
@@ -153,6 +152,7 @@ internal class ArcgisMapView(
             when (call.method) {
                 "zoom_in" -> onZoomIn(call = call, result = result)
                 "zoom_out" -> onZoomOut(call = call, result = result)
+                "rotate" -> onRotate(call = call, result = result)
                 "add_view_padding" -> onAddViewPadding(call = call, result = result)
                 "set_interaction" -> onSetInteraction(call = call, result = result)
                 "move_camera" -> onMoveCamera(call = call, result = result)
@@ -454,6 +454,11 @@ internal class ArcgisMapView(
         } catch (e: Throwable) {
             result.finishWithError(e)
         }
+    }
+
+    private fun onRotate(call: MethodCall, result: MethodChannel.Result) {
+        val angleDegrees = call.arguments as Double
+        result.finishWithFuture { mapView.setViewpointRotationAsync(angleDegrees) }
     }
 
     private fun onAddViewPadding(call: MethodCall, result: MethodChannel.Result) {

--- a/arcgis_map_sdk_ios/ios/Classes/ArcgisMapView.swift
+++ b/arcgis_map_sdk_ios/ios/Classes/ArcgisMapView.swift
@@ -141,6 +141,7 @@ class ArcgisMapView: NSObject, FlutterPlatformView {
             switch (call.method) {
             case "zoom_in": onZoomIn(call, result)
             case "zoom_out": onZoomOut(call, result)
+            case "rotate" : onRotate(call, result)
             case "add_view_padding": onAddViewPadding(call, result)
             case "set_interaction": onSetInteraction(call, result)
             case "move_camera": onMoveCamera(call, result)
@@ -160,7 +161,7 @@ class ArcgisMapView: NSObject, FlutterPlatformView {
             case "update_is_attribution_text_visible": onUpdateIsAttributionTextVisible(call, result)
             case "export_image" : onExportImage(result)
             case "set_auto_pan_mode": onSetAutoPanMode(call, result)
-            case  "get_auto_pan_mode": onGetAutoPanMode(call,  result)
+            case "get_auto_pan_mode": onGetAutoPanMode(call,  result)
             case "set_wander_extent_factor": onSetWanderExtentFactor( call,  result)
             case "get_wander_extent_factor": onGetWanderExtentFactor( call,  result)
             default:
@@ -219,6 +220,17 @@ class ArcgisMapView: NSObject, FlutterPlatformView {
         }
         let newScale = convertZoomLevelToMapScale(totalZoomLevel)
         mapView.setViewpointScale(newScale) { success in
+            result(success)
+        }
+    }
+    
+    private func onRotate(_ call: FlutterMethodCall, _ result:@escaping FlutterResult) {
+        guard let angleDouble = call.arguments as? Double else {
+            result(FlutterError(code: "missing_data", message: "Invalid arguments", details: nil))
+            return
+        }
+        
+        mapView.setViewpointRotation(angleDouble) { success in
             result(success)
         }
     }

--- a/arcgis_map_sdk_method_channel/lib/src/method_channel_arcgis_map_plugin.dart
+++ b/arcgis_map_sdk_method_channel/lib/src/method_channel_arcgis_map_plugin.dart
@@ -42,8 +42,13 @@ class MethodChannelArcgisMapPlugin extends ArcgisMapPlatform {
   }
 
   @override
-  void setAutoPanMode(String autoPanMode, int mapId) {
-    _methodChannelBuilder(mapId).invokeMethod("set_auto_pan_mode", autoPanMode);
+  Future<void> setAutoPanMode(String autoPanMode, int mapId) {
+    return _methodChannelBuilder(mapId).invokeMethod("set_auto_pan_mode", autoPanMode);
+  }
+
+  @override
+  Future<void> setRotation(double angleDegrees, int mapId) {
+    return _methodChannelBuilder(mapId).invokeMethod("rotate", angleDegrees);
   }
 
   @override

--- a/arcgis_map_sdk_platform_interface/lib/src/arcgis_map_sdk_platform_interface.dart
+++ b/arcgis_map_sdk_platform_interface/lib/src/arcgis_map_sdk_platform_interface.dart
@@ -68,8 +68,12 @@ class ArcgisMapPlatform extends PlatformInterface {
     throw UnimplementedError('setMouseCursor() has not been implemented');
   }
 
-  void setAutoPanMode(String autoPanMode, int mapId) {
+  Future<void> setAutoPanMode(String autoPanMode, int mapId)  {
     throw UnimplementedError('setAutoPanMode() has not been implemented');
+  }
+
+  Future<void> setRotation(double angleDegrees, int mapId) {
+    throw UnimplementedError('setRotation() has not been implemented');
   }
 
   Future<AutoPanMode> getAutoPanMode(int mapId) {

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -30,10 +30,10 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   ArcGIS-Runtime-SDK-iOS: 6ab51d28f8831ac73c00d34998cff3a555fe304f
   ArcGIS-Runtime-Toolkit-iOS: e30bb45bd0bd0152bcb1ec73f9b99022a5c7d02d
-  arcgis_map_sdk_ios: ee1d8dee42e0c11c95cd26afa2a8cb0e7a69cb23
+  arcgis_map_sdk_ios: deb0d9d2dfedca86984c0aa81e6245eed03c8344
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
-  geolocator_apple: cc556e6844d508c95df1e87e3ea6fa4e58c50401
+  geolocator_apple: d981750b9f47dbdb02427e1476d9a04397beb8d9
 
 PODFILE CHECKSUM: cc1f88378b4bfcf93a6ce00d2c587857c6008d3b
 
-COCOAPODS: 1.15.2
+COCOAPODS: 1.16.2

--- a/example/ios/Runner/AppDelegate.swift
+++ b/example/ios/Runner/AppDelegate.swift
@@ -1,7 +1,7 @@
 import UIKit
 import Flutter
 
-@UIApplicationMain
+@main
 @objc class AppDelegate: FlutterAppDelegate {
   override func application(
     _ application: UIApplication,

--- a/example/lib/location_indicator_example_page.dart
+++ b/example/lib/location_indicator_example_page.dart
@@ -74,10 +74,7 @@ class _LocationIndicatorExamplePageState extends State<LocationIndicatorExampleP
                 _configureLocationDisplay(Colors.blue);
 
                 _panUpdateSubscription?.cancel();
-                _panUpdateSubscription = controller
-                    .centerPosition()
-                    .debounceTime(const Duration(milliseconds: 50))
-                    .listen((_) => _refreshAutoPanMode());
+                _panUpdateSubscription = controller.centerPosition().listen((_) => _refreshAutoPanMode());
               },
             ),
           ),
@@ -250,12 +247,18 @@ class _LocationIndicatorExamplePageState extends State<LocationIndicatorExampleP
   @override
   void dispose() {
     _panUpdateSubscription?.cancel();
+    _refreshAutoPanModeTimer?.cancel();
     super.dispose();
   }
 
+  Timer? _refreshAutoPanModeTimer;
+
   Future<void> _refreshAutoPanMode() async {
-    final panMode = await _controller!.locationDisplay.getAutoPanMode();
-    if (!mounted) return;
-    setState(() => _activeAutoPanMode = panMode);
+    _refreshAutoPanModeTimer?.cancel();
+    _refreshAutoPanModeTimer = Timer(const Duration(milliseconds: 50), () async {
+      final panMode = await _controller!.locationDisplay.getAutoPanMode();
+      if (!mounted) return;
+      setState(() => _activeAutoPanMode = panMode);
+    });
   }
 }

--- a/example/lib/location_indicator_example_page.dart
+++ b/example/lib/location_indicator_example_page.dart
@@ -238,8 +238,7 @@ class _LocationIndicatorExamplePageState extends State<LocationIndicatorExampleP
     );
 
     if (newSetAutoPanMode != null) {
-      // No need to use setState
-      _activeAutoPanMode = newSetAutoPanMode;
+      setState(() => _activeAutoPanMode = newSetAutoPanMode);
       _controller?.locationDisplay.setAutoPanMode(newSetAutoPanMode);
     }
     if (_activeAutoPanMode == AutoPanMode.recenter) {

--- a/example/lib/location_indicator_example_page.dart
+++ b/example/lib/location_indicator_example_page.dart
@@ -5,7 +5,6 @@ import 'package:arcgis_example/main.dart';
 import 'package:arcgis_map_sdk/arcgis_map_sdk.dart';
 import 'package:flutter/material.dart';
 import 'package:geolocator/geolocator.dart';
-import 'package:rxdart/rxdart.dart';
 
 class LocationIndicatorExamplePage extends StatefulWidget {
   const LocationIndicatorExamplePage({super.key});

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -274,6 +274,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.8"
+  rxdart:
+    dependency: "direct main"
+    description:
+      name: rxdart
+      sha256: "5c3004a4a8dbb94bd4bf5412a4def4acdaa12e12f269737a5751369e12d1a962"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.28.0"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -274,14 +274,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.8"
-  rxdart:
-    dependency: "direct main"
-    description:
-      name: rxdart
-      sha256: "5c3004a4a8dbb94bd4bf5412a4def4acdaa12e12f269737a5751369e12d1a962"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.28.0"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -11,6 +11,7 @@ environment:
 
 dependencies:
   arcgis_map_sdk: ^0.8.0
+  rxdart: ^0.28.0
 
   cupertino_icons: ^1.0.0
   geolocator: ^10.1.0

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -11,8 +11,6 @@ environment:
 
 dependencies:
   arcgis_map_sdk: ^0.8.0
-  rxdart: ^0.28.0
-
   cupertino_icons: ^1.0.0
   geolocator: ^10.1.0
   flutter:


### PR DESCRIPTION
This PR adds support for rotation for android and iOS and fixes a few smaller issues.
1. Fix a bug where loading the current auto pan mode on android failed due to incorrect mapping
2. Fix a bug where the viewpoint listener emitted NaN values for x and y
3. Make the setPanMode method async

I also updated the example app to make sure that those features can now be tested.