### PR TITLE
Fix web. Platform Image Validation & Map Focus Style Fix

### DIFF
--- a/arcgis_map_sdk_android/android/src/main/kotlin/dev/fluttercommunity/arcgis_map_sdk_android/util/GraphicsParser.kt
+++ b/arcgis_map_sdk_android/android/src/main/kotlin/dev/fluttercommunity/arcgis_map_sdk_android/util/GraphicsParser.kt
@@ -125,6 +125,9 @@ class GraphicsParser(private val binding: FlutterPluginBinding) {
 
         // return local asset in case its a local path
         if (!payload.assetUri.isWebUrl()) {
+            if (!payload.assetUri.endsWith(".png", ignoreCase = true)) {
+                throw IllegalArgumentException("Local assetUri must have type .png. Got ${payload.assetUri}")
+            }
             return PictureMarkerSymbol.createWithImage(getBitmapFromAssetPath(payload.assetUri)!!)
                 .apply {
                     width = payload.width.toFloat()

--- a/arcgis_map_sdk_ios/ios/arcgis_map_sdk_ios/Sources/arcgis_map_sdk_ios/GraphicsParser.swift
+++ b/arcgis_map_sdk_ios/ios/arcgis_map_sdk_ios/Sources/arcgis_map_sdk_ios/GraphicsParser.swift
@@ -136,10 +136,13 @@ class GraphicsParser {
         return symbol
     }
 
-    private func parsePictureMarkerSymbol(_ dictionary: [String: Any]) -> Symbol {
+    private func parsePictureMarkerSymbol(_ dictionary: [String: Any]) throws -> Symbol {
         let payload: PictureMarkerSymbolPayload = try! JsonUtil.objectOfJson(dictionary)
 
         if(!payload.assetUri.isWebUrl()) {
+            if !payload.assetUri.lowercased().hasSuffix(".png") {
+                throw ParseException(message: "Local assetUri must have type .png. Got \(payload.assetUri)")
+            }
             let uiImage = getFlutterUiImage(payload.assetUri)
             let symbol = PictureMarkerSymbol(image: uiImage!)
             symbol.width = payload.width

--- a/arcgis_map_sdk_platform_interface/lib/src/types/symbol.dart
+++ b/arcgis_map_sdk_platform_interface/lib/src/types/symbol.dart
@@ -97,10 +97,7 @@ class PictureMarkerSymbol extends Symbol {
     required this.height,
     this.xOffset = 0,
     this.yOffset = 0,
-  }) : assert(
-          assertLocalAssetIsPng(assetUri),
-          "Local assetUri must have type .png. Got $assetUri.",
-        );
+  });
 
   /// Add a [assetUri] of an image to display it as a marker in the whole feature layer
   /// This can be a url or a local path in which the image is stored locally.
@@ -111,13 +108,6 @@ class PictureMarkerSymbol extends Symbol {
   final double height;
   final int xOffset;
   final int yOffset;
-
-  static bool assertLocalAssetIsPng(String assetUri) {
-    if (assetUri.startsWith("https://") || assetUri.startsWith("http://")) {
-      return true;
-    }
-    return assetUri.endsWith(".png");
-  }
 }
 
 /// Set the [fillColor] and other attributes of the polygon displayed in the map

--- a/arcgis_map_sdk_web/assets/css_overrides/override_outline.css
+++ b/arcgis_map_sdk_web/assets/css_overrides/override_outline.css
@@ -1,3 +1,4 @@
 /* This override is used to disable the blue border shown when interacting with the map*/
+/* According to https://community.esri.com/t5/arcgis-javascript-maps-sdk-questions/arcgis-js-api-4-remove-blue-frame-outline-around/td-p/311767 */
 @import"../arcgis_js_api_custom_build/assets/esri/css/main.css";
- body .esri-view .esri-view-surface--inset-outline:focus::after {outline: none !important;}
+ body .esri-view .esri-view-surface--touch-none:focus::after { outline: none !important;}


### PR DESCRIPTION
1. Image extension assertions for picture parsing are now platform-specific. Web is no longer restricted to PNG, while Android/iOS still enforce PNG-only.
2. Updated map styles to remove blue focus borders that appeared after a recent SDK bump.